### PR TITLE
Added a helper method for date normalisation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@org-quicko/core",
-	"version": "2.0.5",
+	"version": "2.0.6",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@org-quicko/core",
-			"version": "2.0.5",
+			"version": "2.0.6",
 			"license": "ISC",
 			"dependencies": {
 				"@date-fns/tz": "^1.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@org-quicko/core",
-	"version": "2.0.6",
+	"version": "2.0.5",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@org-quicko/core",
-			"version": "2.0.6",
+			"version": "2.0.5",
 			"license": "ISC",
 			"dependencies": {
 				"@date-fns/tz": "^1.1.2",
@@ -2634,17 +2634,17 @@
 			"license": "MIT"
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "8.58.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.58.0.tgz",
-			"integrity": "sha512-RLkVSiNuUP1C2ROIWfqX+YcUfLaSnxGE/8M+Y57lopVwg9VTYYfhuz15Yf1IzCKgZj6/rIbYTmJCUSqr76r0Wg==",
+			"version": "8.58.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.58.1.tgz",
+			"integrity": "sha512-eSkwoemjo76bdXl2MYqtxg51HNwUSkWfODUOQ3PaTLZGh9uIWWFZIjyjaJnex7wXDu+TRx+ATsnSxdN9YWfRTQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/regexpp": "^4.12.2",
-				"@typescript-eslint/scope-manager": "8.58.0",
-				"@typescript-eslint/type-utils": "8.58.0",
-				"@typescript-eslint/utils": "8.58.0",
-				"@typescript-eslint/visitor-keys": "8.58.0",
+				"@typescript-eslint/scope-manager": "8.58.1",
+				"@typescript-eslint/type-utils": "8.58.1",
+				"@typescript-eslint/utils": "8.58.1",
+				"@typescript-eslint/visitor-keys": "8.58.1",
 				"ignore": "^7.0.5",
 				"natural-compare": "^1.4.0",
 				"ts-api-utils": "^2.5.0"
@@ -2657,22 +2657,22 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"@typescript-eslint/parser": "^8.58.0",
+				"@typescript-eslint/parser": "^8.58.1",
 				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
 				"typescript": ">=4.8.4 <6.1.0"
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "8.58.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.58.0.tgz",
-			"integrity": "sha512-rLoGZIf9afaRBYsPUMtvkDWykwXwUPL60HebR4JgTI8mxfFe2cQTu3AGitANp4b9B2QlVru6WzjgB2IzJKiCSA==",
+			"version": "8.58.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.58.1.tgz",
+			"integrity": "sha512-gGkiNMPqerb2cJSVcruigx9eHBlLG14fSdPdqMoOcBfh+vvn4iCq2C8MzUB89PrxOXk0y3GZ1yIWb9aOzL93bw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "8.58.0",
-				"@typescript-eslint/types": "8.58.0",
-				"@typescript-eslint/typescript-estree": "8.58.0",
-				"@typescript-eslint/visitor-keys": "8.58.0",
+				"@typescript-eslint/scope-manager": "8.58.1",
+				"@typescript-eslint/types": "8.58.1",
+				"@typescript-eslint/typescript-estree": "8.58.1",
+				"@typescript-eslint/visitor-keys": "8.58.1",
 				"debug": "^4.4.3"
 			},
 			"engines": {
@@ -2688,14 +2688,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/project-service": {
-			"version": "8.58.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.58.0.tgz",
-			"integrity": "sha512-8Q/wBPWLQP1j16NxoPNIKpDZFMaxl7yWIoqXWYeWO+Bbd2mjgvoF0dxP2jKZg5+x49rgKdf7Ck473M8PC3V9lg==",
+			"version": "8.58.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.58.1.tgz",
+			"integrity": "sha512-gfQ8fk6cxhtptek+/8ZIqw8YrRW5048Gug8Ts5IYcMLCw18iUgrZAEY/D7s4hkI0FxEfGakKuPK/XUMPzPxi5g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/tsconfig-utils": "^8.58.0",
-				"@typescript-eslint/types": "^8.58.0",
+				"@typescript-eslint/tsconfig-utils": "^8.58.1",
+				"@typescript-eslint/types": "^8.58.1",
 				"debug": "^4.4.3"
 			},
 			"engines": {
@@ -2710,14 +2710,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "8.58.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.58.0.tgz",
-			"integrity": "sha512-W1Lur1oF50FxSnNdGp3Vs6P+yBRSmZiw4IIjEeYxd8UQJwhUF0gDgDD/W/Tgmh73mxgEU3qX0Bzdl/NGuSPEpQ==",
+			"version": "8.58.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.58.1.tgz",
+			"integrity": "sha512-TPYUEqJK6avLcEjumWsIuTpuYODTTDAtoMdt8ZZa93uWMTX13Nb8L5leSje1NluammvU+oI3QRr5lLXPgihX3w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.58.0",
-				"@typescript-eslint/visitor-keys": "8.58.0"
+				"@typescript-eslint/types": "8.58.1",
+				"@typescript-eslint/visitor-keys": "8.58.1"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2728,9 +2728,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/tsconfig-utils": {
-			"version": "8.58.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.58.0.tgz",
-			"integrity": "sha512-doNSZEVJsWEu4htiVC+PR6NpM+pa+a4ClH9INRWOWCUzMst/VA9c4gXq92F8GUD1rwhNvRLkgjfYtFXegXQF7A==",
+			"version": "8.58.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.58.1.tgz",
+			"integrity": "sha512-JAr2hOIct2Q+qk3G+8YFfqkqi7sC86uNryT+2i5HzMa2MPjw4qNFvtjnw1IiA1rP7QhNKVe21mSSLaSjwA1Olw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -2745,15 +2745,15 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "8.58.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.58.0.tgz",
-			"integrity": "sha512-aGsCQImkDIqMyx1u4PrVlbi/krmDsQUs4zAcCV6M7yPcPev+RqVlndsJy9kJ8TLihW9TZ0kbDAzctpLn5o+lOg==",
+			"version": "8.58.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.58.1.tgz",
+			"integrity": "sha512-HUFxvTJVroT+0rXVJC7eD5zol6ID+Sn5npVPWoFuHGg9Ncq5Q4EYstqR+UOqaNRFXi5TYkpXXkLhoCHe3G0+7w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.58.0",
-				"@typescript-eslint/typescript-estree": "8.58.0",
-				"@typescript-eslint/utils": "8.58.0",
+				"@typescript-eslint/types": "8.58.1",
+				"@typescript-eslint/typescript-estree": "8.58.1",
+				"@typescript-eslint/utils": "8.58.1",
 				"debug": "^4.4.3",
 				"ts-api-utils": "^2.5.0"
 			},
@@ -2770,9 +2770,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "8.58.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.0.tgz",
-			"integrity": "sha512-O9CjxypDT89fbHxRfETNoAnHj/i6IpRK0CvbVN3qibxlLdo5p5hcLmUuCCrHMpxiWSwKyI8mCP7qRNYuOJ0Uww==",
+			"version": "8.58.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.1.tgz",
+			"integrity": "sha512-io/dV5Aw5ezwzfPBBWLoT+5QfVtP8O7q4Kftjn5azJ88bYyp/ZMCsyW1lpKK46EXJcaYMZ1JtYj+s/7TdzmQMw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -2784,16 +2784,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "8.58.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.58.0.tgz",
-			"integrity": "sha512-7vv5UWbHqew/dvs+D3e1RvLv1v2eeZ9txRHPnEEBUgSNLx5ghdzjHa0sgLWYVKssH+lYmV0JaWdoubo0ncGYLA==",
+			"version": "8.58.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.58.1.tgz",
+			"integrity": "sha512-w4w7WR7GHOjqqPnvAYbazq+Y5oS68b9CzasGtnd6jIeOIeKUzYzupGTB2T4LTPSv4d+WPeccbxuneTFHYgAAWg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/project-service": "8.58.0",
-				"@typescript-eslint/tsconfig-utils": "8.58.0",
-				"@typescript-eslint/types": "8.58.0",
-				"@typescript-eslint/visitor-keys": "8.58.0",
+				"@typescript-eslint/project-service": "8.58.1",
+				"@typescript-eslint/tsconfig-utils": "8.58.1",
+				"@typescript-eslint/types": "8.58.1",
+				"@typescript-eslint/visitor-keys": "8.58.1",
 				"debug": "^4.4.3",
 				"minimatch": "^10.2.2",
 				"semver": "^7.7.3",
@@ -2812,16 +2812,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "8.58.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.58.0.tgz",
-			"integrity": "sha512-RfeSqcFeHMHlAWzt4TBjWOAtoW9lnsAGiP3GbaX9uVgTYYrMbVnGONEfUCiSss+xMHFl+eHZiipmA8WkQ7FuNA==",
+			"version": "8.58.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.58.1.tgz",
+			"integrity": "sha512-Ln8R0tmWC7pTtLOzgJzYTXSCjJ9rDNHAqTaVONF4FEi2qwce8mD9iSOxOpLFFvWp/wBFlew0mjM1L1ihYWfBdQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.9.1",
-				"@typescript-eslint/scope-manager": "8.58.0",
-				"@typescript-eslint/types": "8.58.0",
-				"@typescript-eslint/typescript-estree": "8.58.0"
+				"@typescript-eslint/scope-manager": "8.58.1",
+				"@typescript-eslint/types": "8.58.1",
+				"@typescript-eslint/typescript-estree": "8.58.1"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2836,13 +2836,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "8.58.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.58.0.tgz",
-			"integrity": "sha512-XJ9UD9+bbDo4a4epraTwG3TsNPeiB9aShrUneAVXy8q4LuwowN+qu89/6ByLMINqvIMeI9H9hOHQtg/ijrYXzQ==",
+			"version": "8.58.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.58.1.tgz",
+			"integrity": "sha512-y+vH7QE8ycjoa0bWciFg7OpFcipUuem1ujhrdLtq1gByKwfbC7bPeKsiny9e0urg93DqwGcHey+bGRKCnF1nZQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.58.0",
+				"@typescript-eslint/types": "8.58.1",
 				"eslint-visitor-keys": "^5.0.0"
 			},
 			"engines": {
@@ -3438,9 +3438,9 @@
 			}
 		},
 		"node_modules/baseline-browser-mapping": {
-			"version": "2.10.15",
-			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.15.tgz",
-			"integrity": "sha512-1nfKCq9wuAZFTkA2ey/3OXXx7GzFjLdkTiFVNwlJ9WqdI706CZRIhEqjuwanjMIja+84jDLa9rcyZDPDiVkASQ==",
+			"version": "2.10.17",
+			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.17.tgz",
+			"integrity": "sha512-HdrkN8eVG2CXxeifv/VdJ4A4RSra1DTW8dc/hdxzhGHN8QePs6gKaWM9pHPcpCoxYZJuOZ8drHmbdpLHjCYjLA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
@@ -3561,9 +3561,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001786",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001786.tgz",
-			"integrity": "sha512-4oxTZEvqmLLrERwxO76yfKM7acZo310U+v4kqexI2TL1DkkUEMT8UijrxxcnVdxR3qkVf5awGRX+4Z6aPHVKrA==",
+			"version": "1.0.30001787",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001787.tgz",
+			"integrity": "sha512-mNcrMN9KeI68u7muanUpEejSLghOKlVhRqS/Za2IeyGllJ9I9otGpR9g3nsw7n4W378TE/LyIteA0+/FOZm4Kg==",
 			"dev": true,
 			"funding": [
 				{
@@ -3912,9 +3912,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.5.331",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.331.tgz",
-			"integrity": "sha512-IbxXrsTlD3hRodkLnbxAPP4OuJYdWCeM3IOdT+CpcMoIwIoDfCmRpEtSPfwBXxVkg9xmBeY7Lz2Eo2TDn/HC3Q==",
+			"version": "1.5.334",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.334.tgz",
+			"integrity": "sha512-mgjZAz7Jyx1SRCwEpy9wefDS7GvNPazLthHg8eQMJ76wBdGQQDW33TCrUTvQ4wzpmOrv2zrFoD3oNufMdyMpog==",
 			"dev": true,
 			"license": "ISC"
 		},
@@ -6299,9 +6299,9 @@
 			}
 		},
 		"node_modules/path-scurry/node_modules/lru-cache": {
-			"version": "11.3.0",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.0.tgz",
-			"integrity": "sha512-sr8xPKE25m6vJVcrdn6NxtC0fVfuPowbscLypegRgOm0yXSqr5JNHCAY3hnusdJ7HRBW04j6Ip4khvHU778DuQ==",
+			"version": "11.3.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.3.tgz",
+			"integrity": "sha512-JvNw9Y81y33E+BEYPr0U7omo+U9AySnsMsEiXgwT6yqd31VQWTLNQqmT4ou5eqPFUrTfIDFta2wKhB1hyohtAQ==",
 			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"engines": {
@@ -7032,14 +7032,14 @@
 			"license": "MIT"
 		},
 		"node_modules/tinyglobby": {
-			"version": "0.2.15",
-			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-			"integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+			"version": "0.2.16",
+			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+			"integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"fdir": "^6.5.0",
-				"picomatch": "^4.0.3"
+				"picomatch": "^4.0.4"
 			},
 			"engines": {
 				"node": ">=12.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@org-quicko/core",
-	"version": "2.0.4",
+	"version": "2.0.6",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@org-quicko/core",
-			"version": "2.0.4",
+			"version": "2.0.6",
 			"license": "ISC",
 			"dependencies": {
 				"@date-fns/tz": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@org-quicko/core",
-	"version": "2.0.5",
+	"version": "2.0.6",
 	"description": "A library in typescript for common entities and utilities across Quicko",
 	"author": "Quicko",
 	"main": "dist/cjs/build/node/index.cjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@org-quicko/core",
-	"version": "2.0.6",
+	"version": "2.0.5",
 	"description": "A library in typescript for common entities and utilities across Quicko",
 	"author": "Quicko",
 	"main": "dist/cjs/build/node/index.cjs",

--- a/src/utils/date/DateUtil.ts
+++ b/src/utils/date/DateUtil.ts
@@ -54,7 +54,7 @@ export class DateUtil {
     static printDate(date: Date, timeZone: string, dateFormat?: string): string;
     static printDate(date: number, timeZone: string, dateFormat?: string): string;
     static printDate(date: Date | number, timeZone: string, dateFormat: string = this.ISO_8601_FORMAT): string {
-        const normalizedDate = typeof date === 'number' ? DateUtil.fromMillis(date) : date;
+        const normalizedDate = this.normalizeDate(date);
         return format(new TZDate(normalizedDate, timeZone), dateFormat);
     }
 
@@ -67,7 +67,7 @@ export class DateUtil {
     static getStartOfDay(date: Date, timeZone: string): Date;
     static getStartOfDay(date: number, timeZone: string): Date;
     static getStartOfDay(date: Date | number, timeZone: string): Date {
-        const normalizedDate = typeof date === 'number' ? DateUtil.fromMillis(date) : date;
+        const normalizedDate = this.normalizeDate(date);
         return startOfDay(new TZDate(normalizedDate, timeZone));
     }
 
@@ -80,7 +80,7 @@ export class DateUtil {
     static getEndOfDay(date: Date, timeZone: string): Date;
     static getEndOfDay(date: number, timeZone: string): Date;
     static getEndOfDay(date: Date | number, timeZone: string): Date {
-        const normalizedDate = typeof date === 'number' ? DateUtil.fromMillis(date) : date;
+        const normalizedDate = this.normalizeDate(date);
         return endOfDay(new TZDate(normalizedDate, timeZone));
     }
 
@@ -112,8 +112,8 @@ export class DateUtil {
     static daysInBetween(firstDate: Date, secondDate: Date, timeZone?: string): number;
     static daysInBetween(firstDate: number, secondDate: number, timeZone?: string): number;
     static daysInBetween(firstDate: Date | number, secondDate: Date | number, timeZone?: string): number {
-        const first = typeof firstDate === 'number' ? DateUtil.fromMillis(firstDate) : firstDate;
-        const second = typeof secondDate === 'number' ? DateUtil.fromMillis(secondDate) : secondDate;
+        const first = this.normalizeDate(firstDate);
+        const second = this.normalizeDate(secondDate);
         const effectiveTimeZone = timeZone || this.TIMEZONE;
         return Math.abs(
             differenceInCalendarDays(
@@ -136,8 +136,8 @@ export class DateUtil {
     static monthsInBetween(firstDate: Date, secondDate: Date, timeZone?: string): number;
     static monthsInBetween(firstDate: number, secondDate: number, timeZone?: string): number;
     static monthsInBetween(firstDate: Date | number, secondDate: Date | number, timeZone?: string): number {
-        const first = typeof firstDate === 'number' ? DateUtil.fromMillis(firstDate) : firstDate;
-        const second = typeof secondDate === 'number' ? DateUtil.fromMillis(secondDate) : secondDate;
+        const first = this.normalizeDate(firstDate);
+        const second = this.normalizeDate(secondDate);
         const effectiveTimeZone = timeZone || this.TIMEZONE;
         return Math.abs(
             differenceInCalendarMonths(
@@ -160,8 +160,8 @@ export class DateUtil {
     static yearsInBetween(firstDate: Date, secondDate: Date, timeZone?: string): number;
     static yearsInBetween(firstDate: number, secondDate: number, timeZone?: string): number;
     static yearsInBetween(firstDate: Date | number, secondDate: Date | number, timeZone?: string): number {
-        const first = typeof firstDate === 'number' ? DateUtil.fromMillis(firstDate) : firstDate;
-        const second = typeof secondDate === 'number' ? DateUtil.fromMillis(secondDate) : secondDate;
+        const first = this.normalizeDate(firstDate);
+        const second = this.normalizeDate(secondDate);
         const effectiveTimeZone = timeZone || this.TIMEZONE;
         return Math.abs(
             differenceInCalendarYears(
@@ -182,8 +182,8 @@ export class DateUtil {
     static hoursInBetween(firstDate: Date, secondDate: Date): number;
     static hoursInBetween(firstDate: number, secondDate: number): number;
     static hoursInBetween(firstDate: Date | number, secondDate: Date | number): number {
-        const first = typeof firstDate === 'number' ? DateUtil.fromMillis(firstDate) : firstDate;
-        const second = typeof secondDate === 'number' ? DateUtil.fromMillis(secondDate) : secondDate;
+        const first = this.normalizeDate(firstDate);
+        const second = this.normalizeDate(secondDate);
         return Math.abs(differenceInHours(first, second));
     }
 
@@ -198,8 +198,8 @@ export class DateUtil {
     static secondsInBetween(firstDate: Date, secondDate: Date): number;
     static secondsInBetween(firstDate: number, secondDate: number): number;
     static secondsInBetween(firstDate: Date | number, secondDate: Date | number): number {
-        const first = typeof firstDate === 'number' ? DateUtil.fromMillis(firstDate) : firstDate;
-        const second = typeof secondDate === 'number' ? DateUtil.fromMillis(secondDate) : secondDate;
+        const first = this.normalizeDate(firstDate);
+        const second = this.normalizeDate(secondDate);
         return Math.abs(differenceInSeconds(first, second));
     }
 
@@ -212,8 +212,8 @@ export class DateUtil {
     static compareDates(firstDate: Date, secondDate: Date): -1 | 0 | 1;
     static compareDates(firstDate: number, secondDate: number): -1 | 0 | 1;
     static compareDates(firstDate: Date | number, secondDate: Date | number): -1 | 0 | 1 {
-        const first = typeof firstDate === 'number' ? DateUtil.fromMillis(firstDate) : firstDate;
-        const second = typeof secondDate === 'number' ? DateUtil.fromMillis(secondDate) : secondDate;
+        const first = this.normalizeDate(firstDate);
+        const second = this.normalizeDate(secondDate);
 
         return compareAsc(first, second) as -1 | 0 | 1;
     }
@@ -231,7 +231,7 @@ export class DateUtil {
     static addDuration(date: Date, duration: Duration, timeZone?: string): Date;
     static addDuration(date: number, duration: Duration, timeZone?: string): Date;
     static addDuration(date: Date | number, duration: Duration, timeZone?: string): Date {
-        const normalizedDate = typeof date === 'number' ? DateUtil.fromMillis(date) : date;
+        const normalizedDate = this.normalizeDate(date);
         const effectiveTimeZone = timeZone || this.TIMEZONE;
         return add(new TZDate(normalizedDate, effectiveTimeZone), duration);
     }
@@ -253,6 +253,10 @@ export class DateUtil {
      */
     static fromMillis(milliseconds: number): Date {
         return new Date(milliseconds);
+    }
+
+    protected static normalizeDate(date: Date | number): Date {
+        return typeof date === 'number' ? this.fromMillis(date) : date;
     }
 
     /**


### PR DESCRIPTION
This pull request refactors the `DateUtil` class to improve code maintainability and consistency when handling date inputs. The main change is the introduction of a new `normalizeDate` helper method, which centralizes the logic for converting numeric timestamps to `Date` objects. This method is now used throughout the class, replacing repeated inline checks.

Refactoring for date normalization:

* Added a protected static `normalizeDate` method to `DateUtil`, which converts a number to a `Date` object or returns the `Date` as is. This centralizes and simplifies date normalization logic.
* Updated all methods in `DateUtil` that previously checked and converted numeric date arguments inline to use the new `normalizeDate` method instead, improving readability and reducing code duplication. [[1]](diffhunk://#diff-4b786b94e40ba17182c26d9982c5226be1811bd24f008aece78998122d3011aaL57-R57) [[2]](diffhunk://#diff-4b786b94e40ba17182c26d9982c5226be1811bd24f008aece78998122d3011aaL70-R70) [[3]](diffhunk://#diff-4b786b94e40ba17182c26d9982c5226be1811bd24f008aece78998122d3011aaL83-R83) [[4]](diffhunk://#diff-4b786b94e40ba17182c26d9982c5226be1811bd24f008aece78998122d3011aaL115-R116) [[5]](diffhunk://#diff-4b786b94e40ba17182c26d9982c5226be1811bd24f008aece78998122d3011aaL139-R140) [[6]](diffhunk://#diff-4b786b94e40ba17182c26d9982c5226be1811bd24f008aece78998122d3011aaL163-R164) [[7]](diffhunk://#diff-4b786b94e40ba17182c26d9982c5226be1811bd24f008aece78998122d3011aaL185-R186) [[8]](diffhunk://#diff-4b786b94e40ba17182c26d9982c5226be1811bd24f008aece78998122d3011aaL201-R202) [[9]](diffhunk://#diff-4b786b94e40ba17182c26d9982c5226be1811bd24f008aece78998122d3011aaL215-R216) [[10]](diffhunk://#diff-4b786b94e40ba17182c26d9982c5226be1811bd24f008aece78998122d3011aaL234-R234)

Version bump:

* Incremented the package version from `2.0.5` to `2.0.6` in `package.json` to reflect these internal improvements.