### PR TITLE
Fix package.json and improve README clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# core
+# @org-quicko/core
 
-Foundational Node.js library built with TypeScript used across Quicko.
+Foundational TypeScript library used across Quicko for shared beans, types, utilities, logger helpers, and exceptions.
 
 ## Installation
 
@@ -8,26 +8,49 @@ Foundational Node.js library built with TypeScript used across Quicko.
 npm install @org-quicko/core
 ```
 
+## Local Development
+
+```bash
+npm ci
+npm run lint
+npm run build
+npm run test
+```
+
 ## Release Flow
 
-This repository uses GitHub Actions to separate pull request validation, release drafting, and npm publishing.
+This repo uses GitHub Actions for:
 
-- Pull requests run install, date util tests, and build validation.
-- Pushes to `main` update the next draft release using Release Drafter.
-- Publishing happens only when a GitHub release is published.
-- PR titles are used directly in the drafted release notes, so keep them clear and specific.
-- PR labels influence both release note grouping and version bump resolution.
+- pull request validation
+- release drafting on `main`
+- npm publish when a GitHub release is published
 
-### Publishing A New Version
+PR titles are used in release notes, and labels (`major`, `minor`, `patch`) drive the draft version bump.
 
-1. Update the version in `package.json`.
+## Publishing
+
+1. Update `package.json` version.
 2. Merge the change into `main`.
-3. Review the drafted GitHub release.
-4. Publish the release with a tag that matches the package version, for example `v2.0.4`.
+3. Review the draft release on GitHub.
+4. Publish the release with a tag that matches the package version.
+
+Example:
+
+- `package.json`: `2.0.5`
+- release tag: `v2.0.5`
 
 When the release is published, GitHub Actions will:
 
-- verify the release tag matches `package.json`
 - run install, tests, and build
 - skip publish if that version already exists on npm
-- publish the package to npm using the configured `NPM_TOKEN`
+- publish to npm with provenance enabled
+
+## Requirements
+
+- GitHub Actions secret: `NPM_TOKEN`
+- correct `package.json` metadata:
+  - `repository.url`
+  - `homepage`
+  - `bugs.url`
+
+If repository metadata does not match `https://github.com/org-quicko/core-js`, npm provenance validation can fail.

--- a/package.json
+++ b/package.json
@@ -3,6 +3,14 @@
 	"version": "2.0.6",
 	"description": "A library in typescript for common entities and utilities across Quicko",
 	"author": "Quicko",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/org-quicko/core-js"
+	},
+	"homepage": "https://github.com/org-quicko/core-js",
+	"bugs": {
+		"url": "https://github.com/org-quicko/core-js/issues"
+	},
 	"main": "dist/cjs/build/node/index.cjs",
 	"module": "dist/esm/build/node/index.js",
 	"browser": "dist/browser/build/browser/index.js",


### PR DESCRIPTION
This pull request improves documentation and package metadata for the `@org-quicko/core` library. The main focus is on clarifying the development, release, and publishing process, as well as ensuring the package metadata is correctly set up for npm provenance and repository links.

**Documentation updates:**

* Expanded the `README.md` to clarify the library's purpose, add local development instructions, and provide a more detailed, step-by-step guide to the release and publishing workflow. Also added notes on required repository metadata for npm provenance.

**Package metadata improvements:**

* Added the `repository`, `homepage`, and `bugs` fields to `package.json` to ensure correct links on npm and to support provenance validation.