### PR TITLE
fix: update GitHub Actions workflows to use latest checkout and setup-node actions

### DIFF
--- a/.github/workflows/draft-or-update-next-release.yml
+++ b/.github/workflows/draft-or-update-next-release.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Capture package version
         shell: bash
@@ -29,7 +29,7 @@ jobs:
           echo "PACKAGE_VERSION=$PACKAGE_VERSION" >> "$GITHUB_ENV"
 
       - name: Update release draft
-        uses: release-drafter/release-drafter@v6
+        uses: release-drafter/release-drafter@v7
         with:
           name: v${{ env.PACKAGE_VERSION }}
           tag: v${{ env.PACKAGE_VERSION }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -11,12 +11,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow files to use the latest major versions of several key actions, ensuring better security, support, and access to the latest features.

**Workflow action version upgrades:**

* Upgraded `actions/checkout` from version 4 to version 6 in `.github/workflows/draft-or-update-next-release.yml`, `.github/workflows/publish.yml`, and `.github/workflows/pull-request.yml` to use the latest improvements and fixes. [[1]](diffhunk://#diff-bc0f5d499264a2691caeacb52a432d8b35c94c4a48b0f3a7ef0896ee95d25a9fL23-R23) [[2]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L18-R21) [[3]](diffhunk://#diff-b71166ed0f585913318ed46933ff9b12901e211de3ac88c40de03f0a944c0ae0L14-R19)
* Upgraded `actions/setup-node` from version 4 to version 6 in `.github/workflows/publish.yml` and `.github/workflows/pull-request.yml` for improved Node.js setup and caching. [[1]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L18-R21) [[2]](diffhunk://#diff-b71166ed0f585913318ed46933ff9b12901e211de3ac88c40de03f0a944c0ae0L14-R19)
* Upgraded `release-drafter/release-drafter` from version 6 to version 7 in `.github/workflows/draft-or-update-next-release.yml` to keep up with the latest features and bug fixes.